### PR TITLE
Add an ’s’ at the end of the customer, donor and volunteer URL paths …

### DIFF
--- a/client/modules/core/app-reducers/menu.js
+++ b/client/modules/core/app-reducers/menu.js
@@ -21,7 +21,8 @@ function getMenu(user) {
 }
 
 function getUserMenuItems(user) {
-  const userType = user.roles[0]
+  // The url paths are 'customers', 'donors' and 'volunteers' so need to add 's' at the end
+  const userType = user.roles[0] + 's'
   if (!user.hasApplied)
     return [
       {


### PR DESCRIPTION
…to be compatible with the routes

There is also another error that comes up when logged in as a customer, donor or volunteer. The CustomerRoutes.js, DonorRoutes.js and VolunteerRouter.js files all have code like this

```
  <Switch>
    {user && user.roles.find(role => role === 'admin') &&
      <Route path={`${match.url}`} exact component={CustomerList} />
    }
```

I think when the first part evaluates to false that causes a problem in the JSX.  I tried to figure out a way around it but haven't come up with anything yet.  Do you have any ideas?
