### PR TITLE
change order of arguments to _.union

### DIFF
--- a/client/modules/donor/donation-reducer.js
+++ b/client/modules/donor/donation-reducer.js
@@ -74,7 +74,7 @@ export default (state = {
       return {
         ...state,
         saving: false,
-        ids: union([action.response.result], state.ids)
+        ids: union(state.ids, [action.response.result])
       }
     case RECEIPT_DONATION_SUCCESS:
       return {

--- a/client/modules/food/food-item-reducer.js
+++ b/client/modules/food/food-item-reducer.js
@@ -55,7 +55,7 @@ export default (state = {
         ...state,
         ids: action.type === actions.DELETE_SUCCESS ?
                               difference(state.ids, result) :
-                              union(result, state.ids),
+                              union(state.ids, result),
         saving: false
       }
     case foodCategoryActions.LOAD_ALL_SUCCESS:

--- a/client/store/utils.js
+++ b/client/store/utils.js
@@ -51,7 +51,7 @@ export const crudReducer = name =>
           ...state,
           ids: action.type === `${name}/DELETE_SUCCESS` ?
                                   difference(state.ids, result) :
-                                  union(result, state.ids),
+                                  union(state.ids, result),
           fetching: false,
           saving: false
         }


### PR DESCRIPTION
does this help with the inventory not updating? I just noticed it too, also that the order of things was changing after updating so tried this and can't reproduce the not updating any more.

I looked after you changed the order of the args to _.difference and from the documentation it didn't sound like it mattered with union, but it seems it does. Can't see why it would fix the updating thing though.