### PR TITLE
Fix issue with editing food items.

### DIFF
--- a/client/modules/food/components/inventory/FoodItem.js
+++ b/client/modules/food/components/inventory/FoodItem.js
@@ -46,7 +46,7 @@ class FoodItem extends React.Component {
   }
 
   onClickSave = () => {
-    this.props.saveItem(this.state.categorySelectValue, {...this.props.foodItem, name: this.state.nameInputValue, categoryId: this.state.categorySelectValue, quantity: this.state.quantityInputValue})
+    this.props.saveItem(this.props.foodItem.categoryId, {...this.props.foodItem, name: this.state.nameInputValue, categoryId: this.state.categorySelectValue, quantity: this.state.quantityInputValue})
     this.setState({showEdit: false})
   }
 


### PR DESCRIPTION
When a food item was edited and the category changed the database would have the food item in both the old and new categorys

I'm not sure if I fixed this correctly but it seems to be working better now. 