### PR TITLE
Fix ‘No foods in inventory matching undefined’ message on the food it…

### DIFF
--- a/client/modules/food/components/inventory/FoodItems.js
+++ b/client/modules/food/components/inventory/FoodItems.js
@@ -17,7 +17,8 @@ class FoodItems extends React.Component {
       // editModalFood is the food being edited in the edit modal
       editModalFood: undefined,
       modalInputFields: { name: "", categoryId: "", quantity: "" },
-      validInput: false
+      validInput: false,
+      searchText: ""
     }
   }
 


### PR DESCRIPTION
Fixes the message "No foods in inventory matching undefined" on the food item page when no search term is specified