### PR TITLE
Allow application to run without google oauth if the API keys are not set

### DIFF
--- a/client/modules/users/components/SignIn.js
+++ b/client/modules/users/components/SignIn.js
@@ -74,12 +74,16 @@ class SignIn extends React.Component {
           </button>&nbsp; or&nbsp;
           <Link to="/users/signup">Sign up</Link>
           <br />
-          or
-          <br />
-          <a href="/api/auth/google"  className="btn btn-default">
-            <i className="fa fa-google" />{' '}
-            Sign in with Google
-          </a>
+          {this.props.googleAuthentication &&
+            <div>
+              or
+              <br />
+              <a href="/api/auth/google"  className="btn btn-default">
+                <i className="fa fa-google" />{' '}
+                Sign in with Google
+              </a> 
+          </div>
+          }
         </div>
         <div className="form-group">
           <Link to="/users/forgot-password">Forgot your password?</Link>
@@ -91,7 +95,8 @@ class SignIn extends React.Component {
 const mapStateToProps = state => ({
   user: selectors.user.getUser(state),
   fetchingUser: selectors.user.fetching(state),
-  fetchUserError: selectors.user.error(state)
+  fetchUserError: selectors.user.error(state),
+  googleAuthentication: (state.settings && state.settings.data) ? state.settings.data.googleAuthentication : false
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/client/modules/users/components/SignUp.js
+++ b/client/modules/users/components/SignUp.js
@@ -140,12 +140,16 @@ class SignUp extends React.Component {
             Sign up
           </button>
           <br />
-          or
-          <br />
-          <a href="/api/auth/google"  className="btn btn-default">
-            <i className="fa fa-google" />{' '}
-            Sign up with Google
-          </a>
+          {this.props.googleAuthentication &&
+            <div>
+              or
+              <br />
+              <a href="/api/auth/google"  className="btn btn-default">
+                <i className="fa fa-google" />{' '}
+                Sign up with Google
+              </a>
+            </div>
+          }
           <br/><br/>Already have an account?&nbsp;&nbsp;
           <Link to="/users/signin">Sign in</Link>
         </div>
@@ -156,7 +160,8 @@ class SignUp extends React.Component {
 const mapStateToProps = state => ({
   user: selectors.user.getUser(state),
   fetchingUser: selectors.user.fetching(state),
-  fetchUserError: selectors.user.error(state)
+  fetchUserError: selectors.user.error(state),
+  googleAuthentication: (state.settings && state.settings.data) ? state.settings.data.googleAuthentication : false
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/server/config/passport.js
+++ b/server/config/passport.js
@@ -1,6 +1,7 @@
 import passport from 'passport'
 import localStrategy from './strategies/local'
 import googleStrategy from './strategies/google'
+import config from './index.js'
 
 export default function() {
   const {User} = require('../models')
@@ -23,7 +24,13 @@ export default function() {
   // Initialize strategies
   localStrategy()
 
-  if (process.env.NODE_ENV !== 'test') {
+  if (config.oauth) {
     googleStrategy()
+  } else if (process.env.NODE_ENV !== 'test') {
+    console.log()
+    console.log('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!')
+    console.log('!!!  Google oauth API keys not set. Google login is disabled  !!!')
+    console.log('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!')
+    console.log()
   }
 }

--- a/server/controllers/settings.js
+++ b/server/controllers/settings.js
@@ -1,5 +1,6 @@
 import {intersection} from 'lodash'
 import Settings from '../models/settings'
+import config from '../config'
 
 export default {
   async read (req, res) {
@@ -7,7 +8,15 @@ export default {
     const projection = user && intersection(user.roles, ['admin', 'driver']).length ?
       '+gmapsApiKey +gmapsClientId' : ''
 
-    const settings = await Settings.findOne().select(projection)
+    const settings = await Settings.findOne().select(projection).lean()
+
+    // Add property to indicate if google authentication is available
+    Object.assign(settings, {googleAuthentication: !!(config.oauth)})
+
+    // Remove unnecessary info before sending off the object to the client
+    delete settings._id
+    delete settings.__v
+
     res.json(settings)
   },
 


### PR DESCRIPTION
This will make it easier for people to deploy the application if they don't want to bother getting a google oauth API key.  If config.oauth is not set it will skip all the code dealing with oauth authentication rather than throw errors.